### PR TITLE
Simplify unsafeIndex.

### DIFF
--- a/Kitty/KTypes/C.hs
+++ b/Kitty/KTypes/C.hs
@@ -451,9 +451,9 @@ instance KSelect C where
   selectList xs (UnsafeC index) =
     fromMaybe (impureThrow $ KSelectIndexOutOfBounds index) $ xs !!? index
 
-  unsafeBoolToZeroOrOne (UnsafeC False) = UnsafeC 0
-  unsafeBoolToZeroOrOne (UnsafeC True) = UnsafeC 1
-  -- Needed for "Kitty.Cat" to not get stuck on the specialization.
+  unsafeBoolToZeroOrOne (UnsafeC False) = 0
+  unsafeBoolToZeroOrOne (UnsafeC True) = 1
+  -- Needed for "Kitty.Plugin" to not get stuck on the specialization.
   {-# INLINE unsafeBoolToZeroOrOne #-}
 
 instance SwitchCase.KIf C where

--- a/Kitty/KTypes/Conditional.hs
+++ b/Kitty/KTypes/Conditional.hs
@@ -13,6 +13,7 @@ module Kitty.KTypes.Conditional
   )
 where
 
+import Data.Vector (Vector)
 import Data.Word (Word8)
 import Kitty.KTypes.BooleanLogic (KAnd)
 import Kitty.Prim (IsPrimitive)
@@ -26,7 +27,7 @@ class KAnd f => KTernary f a | a -> f where
 -- TODO(greg/peddie): clean this up.
 -- TODO(ziyang): can we move KSelect to SwitchCase.hs and merge with KIf?
 class KSelect f where
-  selectList :: IsPrimitive a => [[f a]] -> f Word8 -> [f a]
+  selectList :: IsPrimitive a => [Vector (f a)] -> f Word8 -> Vector (f a)
 
   -- | used to implement 'Kitty.KTypes.kIfThenElse', it better just be 0 or 1
   unsafeBoolToZeroOrOne :: f Bool -> f Word8

--- a/Kitty/KTypes/SwitchCase.hs
+++ b/Kitty/KTypes/SwitchCase.hs
@@ -10,7 +10,6 @@ module Kitty.KTypes.SwitchCase
 where
 
 import qualified Barbies
-import Data.Bool (bool)
 import Data.Functor.Compose (Compose (..))
 import qualified Data.Vector as V
 import Data.Word (Word8)
@@ -27,10 +26,7 @@ class KSelect f => KIf f where
   -- This is dangerous in general, but fine here.
   -- This is the sole purpose for 'unsafeBoolToZeroOrOne'
   kIfThenElse :: forall b. PolyVec f b => f Bool -> b -> b -> b
-  kIfThenElse boolIndex tru fls = switch enumIndex (bool fls tru)
-    where
-      enumIndex :: KEnum f Bool
-      enumIndex = KEnum (unsafeBoolToZeroOrOne boolIndex)
+  kIfThenElse boolIndex tru fls = unsafeIndex [fls, tru] (unsafeBoolToZeroOrOne boolIndex)
 
 switch ::
   forall f a b.
@@ -72,7 +68,7 @@ unsafeIndex allOutputs0 index = either Exception.impureThrow id $ pdevectorize o
           Compose [] (Compose V.Vector f) c ->
           Compose V.Vector f c
         selectPrimList (Compose allPrimOutputs) =
-          Compose . V.fromList $ selectList (V.toList . getCompose <$> allPrimOutputs) index
+          Compose $ selectList (getCompose <$> allPrimOutputs) index
     outputs :: Arrays (Compose V.Vector f)
     outputs = either Exception.impureThrow processOutputs $ traverse pvectorize allOutputs0
 


### PR DESCRIPTION
The type of `selectList` caused us to `V.fromList . toList` on both the
input and output, when everything already wants to deal in Vectors.

BTW, we can't depend on this change until KGen is removed downstream.